### PR TITLE
Update package keywords

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/CrowdStrike/rusty-falcon"
 readme = "README.md"
 edition = "2018"
 license-file = "LICENSE"
-keywords = ["security", "api", "async", "audit", "vulnerability"]
+keywords = ["api", "crowdstrike", "falcon", "security", "vulnerability"]
 categories = ["api-bindings", "asynchronous"]
 
 [dependencies]


### PR DESCRIPTION
Congrats on the first release! Was going through the crates.io listing and would like to propose making the keywords a bit more CrowdStrike specific.

In looking at the crates.io docs there is a limit to 5 keywords [0]. Believe "CrowdStrike" and "Falcon" should be included since those are terms most often associated with the company. Wasn't sure which ones to exclude so took a first stab.


[0] https://doc.rust-lang.org/cargo/reference/manifest.html#the-keywords-field