### PR TITLE
This fixes the hosts example, 

### DIFF
--- a/examples/falcon_host_details.rs
+++ b/examples/falcon_host_details.rs
@@ -32,7 +32,7 @@ async fn get_all_hosts(
             break;
         }
         offset = response.resources[resources_count - 1].clone();
-        details.append(&mut get_device_details(configuration, response.resources).await?);
+        details.append(&mut get_device_details(configuration, &response.resources).await?);
         if resources_count < 5000 {
             break;
         }
@@ -42,15 +42,15 @@ async fn get_all_hosts(
 
 async fn get_device_details(
     configuration: &configuration::Configuration,
-    ids: Vec<String>,
+    ids: &[String],
 ) -> Result<Vec<models::DeviceapiPeriodDeviceSwagger>, Box<dyn error::Error>> {
     let response = hosts_api::post_device_details_v2(
         configuration,
-        crate::models::MsaPeriodIdsRequest::new(ids),
+        crate::models::MsaPeriodIdsRequest::new(ids.to_owned()),
     )
     .await?;
 
-    if !response.errors.is_empty() {
+    if !response.errors.is_none() {
         return Err(ApiError(format!(
             "while getting Falcon Host IDs: '{:?}'",
             response.errors

--- a/src/models/deviceapi_period_device_details_response_swagger.rs
+++ b/src/models/deviceapi_period_device_details_response_swagger.rs
@@ -11,7 +11,7 @@
 #[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
 pub struct DeviceapiPeriodDeviceDetailsResponseSwagger {
     #[serde(rename = "errors")]
-    pub errors: Vec<crate::models::MsaspecPeriodError>,
+    pub errors: Option<Vec<crate::models::MsaspecPeriodError>>,
     #[serde(rename = "meta")]
     pub meta: Box<crate::models::MsaspecPeriodMetaInfo>,
     #[serde(rename = "resources")]
@@ -20,7 +20,7 @@ pub struct DeviceapiPeriodDeviceDetailsResponseSwagger {
 
 impl DeviceapiPeriodDeviceDetailsResponseSwagger {
     pub fn new(
-        errors: Vec<crate::models::MsaspecPeriodError>,
+        errors: Option<Vec<crate::models::MsaspecPeriodError>>,
         meta: crate::models::MsaspecPeriodMetaInfo,
         resources: Vec<crate::models::DeviceapiPeriodDeviceSwagger>,
     ) -> DeviceapiPeriodDeviceDetailsResponseSwagger {


### PR DESCRIPTION
It seems there may be a difference in the definition of the API and possible values.

For Rust it is a huge difference if the api returns a `Vec` or `null`, I'm not sure if this can be defined in the API spec, if not I can add a patch for all the APIs with `Vec<...>` and not `Option<Vec<...>>`.