### PR TITLE
Bump version to 0.3.0 due to API changes from 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusty_falcon"
-version = "0.2.9"
+version = "0.3.0"
 authors = ["CrowdStrike Inc"]
 description = "Rust bindings for CrowdStrike Falcon API"
 homepage = "https://github.com/CrowdStrike/rusty-falcon"


### PR DESCRIPTION
Bumps the version after breeaking changes in d34e5793b76c1db0e38ac839f910bbe704580ba1