### PR TITLE
Add missing negation in the pagination of spotlight example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusty_falcon"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["CrowdStrike Inc"]
 description = "Rust bindings for CrowdStrike Falcon API"
 homepage = "https://github.com/CrowdStrike/rusty-falcon"

--- a/examples/falcon_spotlight_vulnerabilities.rs
+++ b/examples/falcon_spotlight_vulnerabilities.rs
@@ -38,7 +38,7 @@ async fn main() {
         }
 
         after = match response.meta.next() {
-            Some(pagination_token) if pagination_token.is_empty() => {
+            Some(pagination_token) if !pagination_token.is_empty() => {
                 Some(pagination_token.to_owned())
             }
             _ => break,


### PR DESCRIPTION
I missed the negation of the pagination which caused the example to fetch only the first page and then stop.