### PR TITLE
fix: avoid possible truncation by using `i64` for pagination offset

### DIFF
--- a/examples/falcon_custom_ioas.rs
+++ b/examples/falcon_custom_ioas.rs
@@ -30,7 +30,7 @@ async fn main() {
         .expect("Could not authenticate with CrowdStrike API");
 
     let mut details = vec![];
-    let mut offset = 0;
+    let mut offset: i64 = 0;
     loop {
         let response = query_rule_groups_mixin0(
             &falcon.cfg,
@@ -62,7 +62,9 @@ async fn main() {
         details.extend(details_response);
 
         offset = match response.meta.pagination {
-            Some(pagination) if pagination.offset < pagination.total as i32 => pagination.offset,
+            Some(pagination) if i64::from(pagination.offset) < pagination.total => {
+                i64::from(pagination.offset)
+            }
             _ => break,
         };
     }


### PR DESCRIPTION
- Changed the type of `offset` from `i32` to `i64` to prevent potential data loss when casting from `i64` to `i32`.
- This change ensures that the pagination offset can handle large values without risk of truncation.
- Updated the relevant code sections to accommodate this change.