### PR TITLE
Update Dependabot to run on rust as well

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,12 @@
----
 version: 2
 updates:
+- package-ecosystem: cargo
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
-    interval: monthly
-  open-pull-requests-limit: 10
+    interval: daily


### PR DESCRIPTION
This should make the `dependabot` run daily on Rust files as well.