### PR TITLE
Fix issue with is_some.

### DIFF
--- a/examples/falcon_host_details.rs
+++ b/examples/falcon_host_details.rs
@@ -51,7 +51,7 @@ async fn get_device_details(
     )
     .await?;
 
-    if response.errors.is_some() {
+    if !response.errors.is_empty() {
         return Err(ApiError(format!(
             "while getting Falcon Host IDs: '{:?}'",
             response.errors


### PR DESCRIPTION
This fixes an issue in the `falcon_host_details` example.

```
   Compiling rusty_falcon v0.4.0 (/Users/mmadden/src/rusty-falcon)
error[E0599]: no method named `is_some` found for struct `Vec<MsaspecPeriodError>` in the current scope
  --> examples/falcon_host_details.rs:54:24
   |
54 |     if response.errors.is_some() {
   |                        ^^^^^^^
   |
help: there is a method `is_sorted` with a similar name
   |
54 |     if response.errors.is_sorted() {
   |                        ~~~~~~~~~
```