### PR TITLE
[FEATURE] Add a case for the intel_indicators example

### DIFF
--- a/scripts/run-examples.sh
+++ b/scripts/run-examples.sh
@@ -32,12 +32,17 @@ do
         echo "${line_separator}"
         echo "Running ${example_label} example"
 
+        cargo_run_cmd_segment="cargo run --example $example_name"
+
         # Handle example specific mandatory flags / options
         if [ "$example_name" == "falcon_discover_hosts" ]
         then
-            cargo_run="cargo run --example $example_name -- --sort hostname > /dev/null 2>&1"
+            cargo_run="$cargo_run_cmd_segment -- --sort hostname > /dev/null 2>&1"
+        elif [ "$example_name" == "intel_indicators" ]
+        then
+            cargo_run="$cargo_run_cmd_segment -- --sort published_date.asc --filter deleted:false -q ps1 > /dev/null 2>&1"
         else
-            cargo_run="cargo run --example $example_name > /dev/null 2>&1"
+            cargo_run="$cargo_run_cmd_segment > /dev/null 2>&1"
         fi
 
         # Check command error code and exit if any error code


### PR DESCRIPTION
## Description

The `run-examples.sh` script does not handle intel_indicators example that requires special arguments. This PR add this case.

## Changes

- Update `run-examples.sh` script to handle `intel_indicators` case

## Checklist

- [ ] No sensitive information has been committed
- [ ] Changelog file has been updated
- [ ] Code generates no warnings (i.e. `cargo fmt --check`)
- [ ] "Noisy" (WIP) commits have been squashed for better commit hygiene and cleaner history

## Additional Notes

*Any additional information or context relevant to this PR*
