### PR TITLE
chore: Add support for rustls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Docs: Added initial documentation drop
 - Feature: A script (`run-examples.sh`) to run and display the status (pass/fail) of each example
+- Chore: Added `openssl` and `rustls` feature flags to toggle TLS implementation, with `openssl` enabled by default
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,11 @@ default = { extend-ignore-identifiers-re = [
 ] }
 files = { extend-exclude = [] }
 
+[features]
+default = ["openssl"]
+openssl = ["dep:openssl", "dep:openssl-sys", "reqwest/default-tls"]
+rustls = ["reqwest/rustls-tls"]
+
 [dependencies]
 # To satisfy minimal version check
 openssl = { version = "0.10.73", optional = true }
@@ -41,11 +46,6 @@ url = "2.5.2"
 [dev-dependencies]
 clap = { version = "4.5.19", features = ["derive"] }
 tokio = { version = "1.40.0", features = ["rt-multi-thread", "macros"] }
-
-[features]
-default = ["openssl"]
-openssl = ["dep:openssl", "dep:openssl-sys", "reqwest/default-tls"]
-rustls = ["reqwest/rustls-tls"]
 
 [profile.release]
 codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,10 +23,14 @@ files = { extend-exclude = [] }
 
 [dependencies]
 # To satisfy minimal version check
-openssl = "0.10.73"
+openssl = { version = "0.10.73", optional = true }
 # To satisfy minimal version check
-openssl-sys = "0.9.109"
-reqwest = { version = "0.12.20", features = ["json", "multipart"] }
+openssl-sys = { version = "0.9.109", optional = true }
+reqwest = { version = "0.12.20", features = [
+    "charset",
+    "json",
+    "multipart",
+], default-features = false }
 serde = "1.0.210"
 serde_derive = "1.0.210"
 serde_json = "1.0.128"
@@ -37,6 +41,11 @@ url = "2.5.2"
 [dev-dependencies]
 clap = { version = "4.5.19", features = ["derive"] }
 tokio = { version = "1.40.0", features = ["rt-multi-thread", "macros"] }
+
+[features]
+default = ["openssl"]
+openssl = ["dep:openssl", "dep:openssl-sys", "reqwest/default-tls"]
+rustls = ["reqwest/rustls-tls"]
 
 [profile.release]
 codegen-units = 1


### PR DESCRIPTION
## Description

[Rustls](https://github.com/rustls/rustls) is a widely adopted, pure rust TLS implementation. On systems that don't wish to use a native OpenSSL implementation, Rustls gives an alternative that requires no external dependencies. The `reqwest` crate, a dependency of this crate, exposes a feature flag to switch TLS implementations.

Fixes #171

## Changes

Adds 2 new feature flags, `openssl` and `rustls` with `openssl` enabled by default. The in turn toggle feature flags for the TLS implementation used by `reqwest`.

## Checklist

- [ ] Examples work/pass (i.e. run `./scripts/run-examples.sh`)
- [X] No sensitive information has been committed
- [X] Changelog file has been updated
- [x] Code generates no warnings (i.e. `cargo fmt --check`)
- [X] "Noisy" (WIP) commits have been squashed for better commit hygiene and cleaner history

## Additional Notes

Alternatively, we could adopt `rustls` only and remove the `openssl` dependencies all together if desired.