### PR TITLE
deps(openssl): update openssl and openssl-sys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Upgrade dependencies:
   - `clap` to `4.5.18`
-  - `openssl` to `0.10.72`
-  - `openssl-sys` to `0.9.103`
+  - `openssl` to `0.10.73`
+  - `openssl-sys` to `0.9.109`
   - `reqwest` to `0.12.20`
   - `serde` to `1.0.210`
   - `serde_derive` to `1.0.210`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,9 @@ files = { extend-exclude = [] }
 
 [dependencies]
 # To satisfy minimal version check
-openssl = "0.10.72"
+openssl = "0.10.73"
 # To satisfy minimal version check
-openssl-sys = "0.9.103"
+openssl-sys = "0.9.109"
 reqwest = { version = "0.12.20", features = ["json", "multipart"] }
 serde = "1.0.210"
 serde_derive = "1.0.210"


### PR DESCRIPTION
## Description

- Update openssl and openssl-sys to the latest versions

## Changes

- openssl from 0.10.72 to 0.10.73
- openssl-sys from 0.9.103 to 0.9.109
- Update Changelog

## Checklist

- [x] Examples work/pass (i.e. run `./scripts/run-examples.sh`)
- [x] No sensitive information has been committed
- [x] Changelog file has been updated
- [x] Code generates no warnings (i.e. `cargo fmt --check`)
- [x] "Noisy" (WIP) commits have been squashed for better commit hygiene and cleaner history

## Additional Notes

- Raising this PR In order to fix this https://github.com/CrowdStrike/rusty-falcon/pull/174