### PR TITLE
update rustls to enable rustls by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] - 2026-01-28
+
+### Changed
+
+- `BREAKING`: Default TLS backend changed from OpenSSL to rustls - Removed `openssl` and `rustls` feature flags
+- Upgraded `reqwest` to `0.13.1`
+
+### Added
+
+- `native-tls` feature flag for users requiring OpenSSL/native-tls backend
+
+### Removed
+
+- Direct `openssl` and `openssl-sys` dependencies (no longer needed)
+
 ## [0.5.0] - 2025-09-24
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusty_falcon"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["CrowdStrike Inc"]
 description = "Rust bindings for CrowdStrike Falcon API"
 homepage = "https://github.com/CrowdStrike/rusty-falcon"
@@ -22,19 +22,17 @@ default = { extend-ignore-identifiers-re = [
 files = { extend-exclude = [] }
 
 [features]
-default = ["openssl"]
-openssl = ["dep:openssl", "dep:openssl-sys", "reqwest/default-tls"]
-rustls = ["reqwest/rustls-tls"]
+default = []
+native-tls = ["reqwest/native-tls"]
 
 [dependencies]
-# To satisfy minimal version check
-openssl = { version = "0.10.75", optional = true }
-# To satisfy minimal version check
-openssl-sys = { version = "0.9.111", optional = true }
-reqwest = { version = "0.12.28", features = [
+reqwest = { version = "0.13.1", features = [
     "charset",
+    "form",
     "json",
     "multipart",
+    "query",
+    "rustls",
 ], default-features = false }
 serde = "1.0.228"
 serde_derive = "1.0.228"

--- a/docs/src/README.md
+++ b/docs/src/README.md
@@ -22,17 +22,24 @@ After installing the Rust toolchain, clone this repository:
 git clone https://github.com/crowdstrike/rusty-falcon
 ```
 
-The project uses the OpenSSL sys crate thereby you might need to make `cargo` aware
-of the whereabouts of the OpenSSL library. Below, you'll find instructions for
-various OS'es.
+### TLS Backend
 
-Chances are, your system has already got all that's needed of the OpenSSL library.
-If `cargo check` succeeds, you're all set. If it complains about not finding
-OpenSSL, read on.
+By default, rusty-falcon uses `rustls` as its TLS backend.
 
-### APT-based Linux distro's (e.g. Debian and Ubuntu)
+For most users, no additional setup is required. Just run `cargo build` and it will work.
 
-Installing the OpenSSL development files should be all that is required:
+### Using `native-tls` (OpenSSL) Instead
+
+If you need `OpenSSL/native-tls` (for legacy server compatibility), add the `native-tls` feature:
+
+```toml
+[dependencies]
+rusty_falcon = { version = "0.7", features = ["native-tls"] }
+```
+
+When using `native-tls`, you may need to install OpenSSL development files on your system.
+
+### APT-based Linux distros (e.g. Debian and Ubuntu)
 
 ```sh
 sudo apt-get install -y openssl-dev
@@ -54,12 +61,13 @@ Installing the OpenSSL development files should be all that is required:
 brew install openssl
 ```
 
-If `cargo` can't still find the OpenSSL library, please provide a configuration
-files pointing to it like so:
+If `cargo` can't find the OpenSSL library, provide a configuration file pointing to it:
 
-1. Create `.cargo/config.tmol`
+1. Create `.cargo/config.toml`
 2. Add the paths to the configuration file:
+
 ```toml
+[env]
 OPENSSL_INCLUDE_DIR="/usr/local/opt/openssl/include"
 OPENSSL_LIB_DIR="/usr/local/opt/openssl/lib"
 ```
@@ -68,7 +76,7 @@ OPENSSL_LIB_DIR="/usr/local/opt/openssl/lib"
 
 Assuming that the source code is stored at `C:/Users/<ME>/src` and you're using
 the MSVC toolchain with Rust (the most common scenario on Windows), all that's
-needed is cloning the `vcpkg` repo, building and installing the OpenSLL like so:
+needed is cloning the `vcpkg` repo, building and installing OpenSSL:
 
 ```pwsh
 cd C:/Users/<ME>/src
@@ -86,8 +94,9 @@ cd vcpkg
 
 Now, tell `cargo` where to find OpenSSL:
 
-1. Create `.cargo/config.tmol`
+1. Create `.cargo/config.toml`
 2. Add the paths to the configuration file:
+
 ```toml
 [env]
 OPENSSL_LIB_DIR="C:/Users/<ME>/src/vcpkg/packages/openssl_x64-windows/lib"


### PR DESCRIPTION
## Description
Upgrade reqwest from 0.12 to 0.13 and switch the default TLS backend from OpenSSL to rustls, following the upstream reqwest changes.

## Changes

- Upgrade `reqwest` from `0.12.28` to `0.13.1`
- Switch default TLS backend from OpenSSL to rustls
- Update documentation to reflect new TLS defaults
- Bump version to 0.7.0

## Checklist

- [x] Examples work/pass (i.e. run `./scripts/run-examples.sh`)
- [x] No sensitive information has been committed
- [x] Changelog file has been updated
- [x] Code generates no warnings (i.e. `cargo fmt --check`)
- [x] "Noisy" (WIP) commits have been squashed for better commit hygiene and cleaner history

## Additional Notes

Breaking change for users relying on the default OpenSSL backend. Users can opt-in to OpenSSL via the `native-tls` feature:

```toml
[dependencies]
rusty_falcon = { version = "0.7", features = ["native-tls"] }
```

## Additional Notes

*Any additional information or context relevant to this PR*
