### PR TITLE
chore(package): bump reqwest, serde_with and msrv version

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -108,7 +108,7 @@ jobs:
     # https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability
     strategy:
       matrix:
-        msrv: [1.85.0]
+        msrv: [1.88.0]
     name: ubuntu / ${{ matrix.msrv }}
     timeout-minutes: 60
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.1] - 2026-05-01
+
+### Changed
+
+- Updated `reqwest` to `0.13.3`
+- Updated `serde_with` to `3.18.0`
+- Updated `msrv` to `1.88.0`
+
 ## [0.7.0] - 2026-01-28
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ homepage = "https://github.com/CrowdStrike/rusty-falcon"
 repository = "https://github.com/CrowdStrike/rusty-falcon"
 readme = "README.md"
 edition = "2024"
-rust-version = "1.85.0"
+rust-version = "1.88.0"
 license-file = "LICENSE"
 keywords = ["api", "crowdstrike", "falcon", "security", "vulnerability"]
 categories = ["api-bindings", "asynchronous", "web-programming"]
@@ -26,7 +26,7 @@ default = []
 native-tls = ["reqwest/native-tls"]
 
 [dependencies]
-reqwest = { version = "0.13.1", features = [
+reqwest = { version = "0.13.3", features = [
     "charset",
     "form",
     "json",
@@ -37,7 +37,7 @@ reqwest = { version = "0.13.1", features = [
 serde = "1.0.228"
 serde_derive = "1.0.228"
 serde_json = "1.0.149"
-serde_with = "3.16.1"
+serde_with = "3.18.0"
 thiserror = "2.0.18"
 url = "2.5.8"
 


### PR DESCRIPTION
## Description

Update packages and minimum supported Rust version.

## Changes

- Update `reqwest` to `0.13.3`
- Update `serde_with` to `3.18.0`
- Update `msrv` to `1.88.0`

## Checklist

- [x] Examples work/pass (i.e. run `./scripts/run-examples.sh`)
- [x] No sensitive information has been committed
- [x] Changelog file has been updated
- [x] Code generates no warnings (i.e. `cargo fmt --check`)
- [x] "Noisy" (WIP) commits have been squashed for better commit hygiene and cleaner history

## Additional Notes

This is needed to unblock open PRs (like this one https://github.com/CrowdStrike/rusty-falcon/pull/192) and future work.