### PR TITLE
chore: update logo, update X link and add a link to cs subreddit

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -138,8 +138,17 @@ jobs:
         with:
           egress-policy: audit
 
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - run: cargo outdated --exit-code 1
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Install stable
+        uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+      
+      - name: Install outdated
+        run: cargo install cargo-outdated
+        
+      - name: Cargo outdated
+        run: cargo outdated --exit-code 1
 
   block-fixup:
     name: Block fixup commits

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-![CrowdStrike Falcon](https://raw.githubusercontent.com/CrowdStrike/falconpy/main/docs/asset/cs-logo.png) [![Twitter URL](https://img.shields.io/twitter/url?label=Follow%20%40CrowdStrike&style=social&url=https%3A%2F%2Ftwitter.com%2FCrowdStrike)](https://twitter.com/CrowdStrike)<br/>
+![CrowdStrike Falcon](https://raw.githubusercontent.com/CrowdStrike/falconpy/main/docs/asset/cs-logo-red.png#gh-dark-mode-only) 
+[![Twitter URL](https://img.shields.io/twitter/url?label=Follow%20%40CrowdStrike&style=social&url=https%3A%2F%2Ftwitter.com%2FCrowdStrike)](https://x.com/CrowdStrike) [![CrowdStrike Subreddit](https://img.shields.io/badge/-r%2Fcrowdstrike-white?logo=reddit&labelColor=gray&link=https%3A%2F%2Freddit.com%2Fr%2Fcrowdstrike)](https://reddit.com/r/crowdstrike)
 
 # rusty_falcon
 


### PR DESCRIPTION
## Description

Housekeeping, updating info.

## Changes

- Update top logo (current one is difficult to see), can verify here https://github.com/davidc6/rusty-falcon/blob/0362d6880480a205ec57d2530db30b2bde084049/README.md
- Update link to CS X
- Add link to CS subreddit
- Update `cargo outdated` to run on main

## Checklist

- [x] Examples work/pass (i.e. run `./scripts/run-examples.sh`)
- [x] No sensitive information has been committed
- [ ] Changelog file has been updated
- [x] Code generates no warnings (i.e. `cargo fmt --check`)
- [x] "Noisy" (WIP) commits have been squashed for better commit hygiene and cleaner history

## Additional Notes

n/a